### PR TITLE
Concurrent UI

### DIFF
--- a/pdp11.py
+++ b/pdp11.py
@@ -178,16 +178,12 @@ class pdp11Run():
         logging.info('instructions executed report ends')
 
     def cpuThread(self, pdp11):
-        """Run CPU cycles"""
+        """Run CPU cycles in a separate thread"""
         logging.info('cpuThread: begin')
         instructions_done = 0
-        limit = 1000000
         while self.cpu_run:
             self.cpu_run = pdp11.instruction_cycle()
             instructions_done = instructions_done + 1
-            if instructions_done > limit:
-                logging.info('run: instruction limit reached')
-                self.cpu_run = False
             logging.debug(f'run:{self.cpu_run} instructions_done:{instructions_done}')
         self.pdp11.sw.stop("run")
         logging.info(f'cpuThread: end. run:{self.cpu_run}  instructions_done:{instructions_done}')

--- a/pdp11_console.py
+++ b/pdp11_console.py
@@ -47,14 +47,18 @@ class Console:
                                 font=('Arial', 18), finalize=True)
         logging.info('console make_window done')
 
-    def cycle(self, cpu_run):
+    def window_cycle(self, cpu_run):
         '''one console window update window_cycle'''
+        # parameters from PDP11
+        # PC - remove this. It just t akes time.
+        # outputs to PDP11: events
+        # window_run
+        # cpu_run
         self.sw.start('console')
         window_run = True
 
         pc_display = self.window['pc_display']
         pc_display.update(oct(self.pdp11.reg.get_pc()))
-
         pc_lights = self.window['pc_lights']
         pc_lights.update(self.pc_to_blinky_lights())
 

--- a/pdp11_logger.py
+++ b/pdp11_logger.py
@@ -6,7 +6,7 @@ class Logger():
         logFormat = '%(asctime)s.%(msecs)03d000Z %(filename)s:%(funcName)s %(levelname)s : %(message)s'
         dateFormat = '%Y-%m-%dT%H:%M:%S'
         logPath = './pdp11.log'
-        logging.basicConfig(filename=logPath, level=logging.DEBUG, format=logFormat,
+        logging.basicConfig(filename=logPath, level=logging.INFO, format=logFormat,
                             datefmt=dateFormat, force=True, filemode='w')
         logging.Formatter.converter = time.gmtime
         logging.info(f"{logPath} begins")

--- a/pdp11_m9301.py
+++ b/pdp11_m9301.py
@@ -104,7 +104,7 @@ class M9301:
             boot.read_pdp11_assembly_file('source/M9301-YA.txt')
             self.switch_settings = switch81_3 + switch81_4 + switch81_5 + switch81_6 + \
                  switch81_7 + switch81_8 + switch81_9 + switch81_10 + self.base_address
-            logging.info(f'    switch_address:{oct(self.switch_address)} switch_settings:{oct(self.switch_settings)}')
+            logging.info(f'switch_address:{oct(self.switch_address)} switch_settings:{oct(self.switch_settings)}')
             reg.set_pc(self.switch_settings, 'M9301 switch81_2 True')
         else:
             reg.set_pc(0o24,"M9301 else switch81_2 False")

--- a/pdp11_ss_ops.py
+++ b/pdp11_ss_ops.py
@@ -327,7 +327,6 @@ class ss_ops:
             testresult = result & MASK_LOW_BYTE
         else:
             operand = operand | 0o400000  # set the high bit for python weirdness
-            logging.info(f'operand:{bin(operand)}')
             bit15 = operand & 0b1000000000000000
             bit0 = operand & 0b0000000000000001
             result = (operand >> 1) & MASK_WORD | bit15

--- a/pdp11_terminal.py
+++ b/pdp11_terminal.py
@@ -16,7 +16,7 @@ class Terminal:
     # ************************************
     # Cycle the terminal
     def cycle(self):
-        '''One  cycle for terminal'''
+        '''One  window_cycle for terminal'''
         # This is an attenpt to make the terminal automatcaly send LF after CR.
         # If there's a character in our buffer, send it to the DL11
         if self.buffer != 0:

--- a/pdp11_vt52.py
+++ b/pdp11_vt52.py
@@ -19,7 +19,7 @@ class VT52:
     # PySimpleGUI Interface
     # https://pypi.org/project/PySimpleGUI/
     # VT52 has a multiline and ain input_text
-    # These take ~ 1000 uS to read each cycle
+    # These take ~ 1000 uS to read each window_cycle
 
     def make_window(self):
         """create the DL11 emulated terminal using PySimpleGUI"""
@@ -42,6 +42,10 @@ class VT52:
 
     def window_cycle(self):
         '''One PySimpleGUI window_cycle'''
+        # parameters from PDP11
+        # RCSR XCSR XBUF
+        # outputs to PDP11: events
+        # RBUF
         self.sw.start('VT52')
         # If there's a character in our buffer, send it to the DL11
         if self.buffer != 0:

--- a/runpdp11.py
+++ b/runpdp11.py
@@ -7,4 +7,4 @@ pdp11 = PDP11()
 run = pdp11Run(pdp11)
 
 # power on
-run.run_in_VT52_emulator()
+run.run_with_VT52_emulator()

--- a/test_M9301_YA.py
+++ b/test_M9301_YA.py
@@ -14,5 +14,5 @@ class TestClass():
         Boot0 = boot.read_pdp11_assembly_file('source/M9301-YA.txt')
         pdp11.reg.set_pc(0o173000, "test_M9301-YA") # 0o165000
         run = pdp11Run(pdp11)
-        run.run_in_VT52_emulator()
+        run.run_with_VT52_emulator()
 # http://ftpmirror.your.org/pub/misc/bitsavers/pdf/dec/pdp11/xxdp/diag_listings/MAINDEC-11-DQM9A-A-D_M9301_ROM_Bootstrap_Jan77.pdf

--- a/test_M9301_YA_UI.py
+++ b/test_M9301_YA_UI.py
@@ -9,6 +9,6 @@ class TestClass():
         logging.info('test_M9301-YA')
         pdp11 = PDP11(True)
         run = pdp11Run(pdp11)
-        run.run_in_VT52_emulator()
+        run.run_with_VT52_emulator()
 
 # http://ftpmirror.your.org/pub/misc/bitsavers/pdf/dec/pdp11/xxdp/diag_listings/MAINDEC-11-DQM9A-A-D_M9301_ROM_Bootstrap_Jan77.pdf

--- a/test_M9301_YB.py
+++ b/test_M9301_YB.py
@@ -16,4 +16,4 @@ class TestClass():
         Boot0 = pdp11.boot.read_pdp11_assembly_file('source/M9301-YB.txt')
         pdp11.reg.set_pc(0o173000, "test_M9301-YB") # 0o165000
         run = pdp11Run(pdp11)
-        run.run_in_VT52_emulator()
+        run.run_with_VT52_emulator()

--- a/test_M9301_YF.py
+++ b/test_M9301_YF.py
@@ -14,4 +14,4 @@ class TestClass():
         Boot0 = pdp11.boot.read_pdp11_assembly_file('source/M9301-YF.txt')
         pdp11.reg.set_pc(0o173000, "test_M9301-YF") # 0o165000
         run = pdp11Run(pdp11)
-        run.run_in_VT52_emulator()
+        run.run_with_VT52_emulator()

--- a/test_M9301_YH.py
+++ b/test_M9301_YH.py
@@ -15,4 +15,4 @@ class TestClass():
         Boot0 = pdp11.boot.read_pdp11_assembly_file('source/M9301-YH.txt')
         pdp11.reg.set_pc(0o173000, "test_M9301-YH") # 0o165000
         run = pdp11Run(pdp11)
-        run.run_in_VT52_emulator()
+        run.run_with_VT52_emulator()

--- a/test_echo.py
+++ b/test_echo.py
@@ -32,5 +32,5 @@ class TestClass():
         pdp11.reg.set_pc(echo_address, "load_machine_code")
         pdp11.ram.dump(echo_address, echo_address+0o10)
         run = pdp11Run(pdp11)
-        run.run_in_VT52_emulator()
+        run.run_with_VT52_emulator()
 

--- a/test_hello_world.py
+++ b/test_hello_world.py
@@ -67,6 +67,6 @@ class TestClass():
 
         pdp11.reg.set_pc(0o2000, "load_machine_code")
         run = pdp11Run(pdp11)
-        run.run_in_VT52_emulator()
+        run.run_with_VT52_emulator()
         logging.info('test_hello_world done')
 

--- a/test_rss_ops.py
+++ b/test_rss_ops.py
@@ -340,6 +340,7 @@ class TestClass():
         condition_codes = self.psw.get_nzvc()
         #print(f'test_MUL   actual nzvc: {condition_codes}');
         assert condition_codes == CC
+        print(f'test_MUL result:{u.pythonifyPDP11Long(pdp11_actual_product)} = {oct(pdp11_actual_product)}  CC:{condition_codes}')
 
     def test_constants(self):
         print(f'\ntest_constants')

--- a/test_ss_ops.py
+++ b/test_ss_ops.py
@@ -405,7 +405,7 @@ class TestClass():
         run, operand1, operand2, assembly, report = self.ss_ops.do_ss_op(instruction)
         assert assembly == "ASR R1"
         r1 = self.reg.get(1)
-        logging.info(f'r1:{bin(r1)}  {report}')
+        logging.debug(f'r1:{bin(r1)}  {report}')
         assert r1 == 0b1110011000011001
         condition_codes = self.psw.get_nzvc()
         assert condition_codes == "1001" # NZVC


### PR DESCRIPTION
Adds a Python thread to run the CPU in while the pySimpleGui threads can run independently. 
This may want the console to be folded into the VT52.
This will want mutexes for the DL11 registers and for the cpu_run variable. 